### PR TITLE
camera-android: fix build failure with BuildConfig.DEBUG not existing when built with Gradle 8.0+

### DIFF
--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -50,6 +50,8 @@ buildFeatures {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    buildFeatures { buildConfig = true } 
+
     testOptions {
         unitTests.includeAndroidResources = true
         unitTests.returnDefaultValues = true


### PR DESCRIPTION
BuildConfig is no longer provided by default in Gradle 8, so need to add it back in through a build features toggle in build.gradle.

