### PR TITLE
Make BuildConfig available when built with Gradle 8

### DIFF
--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -47,6 +47,8 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    buildFeatures { buildConfig = true } 
+
     testOptions {
         unitTests.includeAndroidResources = true
         unitTests.returnDefaultValues = true


### PR DESCRIPTION
Builds for the Android Camera package are failing when built with Gradle 8 due to BuildConfig no longer being included by default, so update the build.gradle file to add it back in.