### PR TITLE
Remove captureSession.close() call from onClosed() to prevent camera crash

### DIFF
--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -348,11 +348,6 @@ class Camera
             Log.i(TAG, "open | onClosed");
             cameraDevice = null;
 
-            try {
-              closeCaptureSession();
-            } catch (Exception e) {
-              Log.e(TAG, "Exception during closeCaptureSession in onClosed", e);
-            }
             dartMessenger.sendCameraClosingEvent();
           }
 


### PR DESCRIPTION
This PR removes the call to `captureSession.close()` within the `onClosed()` callback of the camera plugin's native code.

We've observed repeated `NullPointerException` crashes during camera shutdown, triggered specifically when calling `close()` on a null or already-disconnected `CameraCaptureSession`. These crashes typically occur under conditions involving USB disconnects or camera reinitialization failures.

After reviewing Android's camera2 API and plugin implementations, it's clear that explicitly calling `captureSession.close()` within `onClosed()` is unnecessary, as the system already handles session closure when the device is closed.

Removing this line has stabilized camera shutdown and eliminated the exception in our tests.
