### PR TITLE
Add support for manual exposure control via setExposureTime

### DIFF
--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -972,6 +972,28 @@ class Camera
   }
 
   /**
+   * Method handler for setting manual sensor exposure time.
+   *
+   * @param result Flutter result.
+   * @param exposureValue Custom exposure value mapped to v4l2 ctrl (unit is NOT nanoseconds).
+   */
+  public void setExposureTime(@NonNull final Result result, int exposureValue) {
+    Log.d("CustomCamera", "Setting exposure to: " + exposureValue);
+    try {
+      previewRequestBuilder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
+      previewRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF);
+      previewRequestBuilder.set(CaptureRequest.SENSOR_EXPOSURE_TIME, (long) exposureValue);
+      captureSession.capture(previewRequestBuilder.build(), null, backgroundHandler);
+      refreshPreviewCaptureSession(
+          () -> result.success(null),
+          (code, message) ->
+              result.error("setExposureTimeFailed", "Could not set exposure time.", null));
+    } catch (Exception e) {
+      result.error("setExposureTimeFailed", e.getMessage(), null);
+    }
+  }
+
+  /**
    * Sets new exposure point from dart.
    *
    * @param result Flutter result.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -169,6 +169,20 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
           }
           break;
         }
+      case "setExposureTime":
+        {
+          Integer exposureValue = call.argument("exposureValue");
+          if (exposureValue == null) {
+            result.error("invalidArgument", "Missing exposureValue", null);
+            return;
+          }
+          try {
+            camera.setExposureTime(result, exposureValue);
+          } catch (Exception e) {
+            handleException(e, result);
+          }
+          break;
+        }
       case "setExposurePoint":
         {
           Boolean reset = call.argument("reset");


### PR DESCRIPTION
### Summary
This PR adds support for manual control of camera exposure time from Flutter using a new method `setExposureTime`.

### Details
- Adds `setExposureTime(int exposureValue)` method to Camera.java
- Handles new method channel call in MethodCallHandlerImpl.java
- Sets CONTROL_AE_MODE to OFF and updates SENSOR_EXPOSURE_TIME
- Invokes a manual capture to ensure the value is applied immediately

### Note
- This value maps to v4l2-ctl's exposure_absolute, and the unit is not nanoseconds
- Requires AOSP camera config to use CamControls enable="request"

### Related ticket
- https://github.com/geappliances/android.appliance-walloven-ui/issues/5087